### PR TITLE
GUNDI-2855: Make post-dispatch file deletion optional

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -38,6 +38,7 @@ DEAD_LETTER_TOPIC = env.str("DEAD_LETTER_TOPIC", "destinations-dead-letter-dev")
 DISPATCHER_EVENTS_TOPIC = env.str("DISPATCHER_EVENTS_TOPIC", "dispatcher-events-dev")
 MAX_EVENT_AGE_SECONDS = env.int("MAX_EVENT_AGE_SECONDS", 86400)  # 24hrs
 BUCKET_NAME = env.str("BUCKET_NAME", "cdip-files-dev")
+DELETE_FILES_AFTER_DELIVERY = env.bool("DELETE_FILES_AFTER_DELIVERY", False)
 
 # Requests rate limitting
 MAX_REQUESTS = env.int("MAX_REQUESTS", 3)

--- a/app/services/dispatchers.py
+++ b/app/services/dispatchers.py
@@ -40,8 +40,14 @@ class WPSWatchCameraTrapDispatcher:
         except Exception as e:
             logger.exception(f"Error sending data to WPS Watch {e}")
             raise e
-        else:  # Remove the file from GCP after delivering it to WPS Watch
-            await gcp_storage.delete(bucket=settings.BUCKET_NAME, object_name=file_name)
+        else:
+            logger.info(f"File {file_name} delivered to WPS Watch with success.")
+            # Remove the file from GCP after delivering it to WPS Watch
+            if settings.DELETE_FILES_AFTER_DELIVERY:
+                await gcp_storage.delete(
+                    bucket=settings.BUCKET_NAME, object_name=file_name
+                )
+                logger.debug(f"File {file_name} deleted from GCP.")
             return result
 
     # ToDo: Make a WPS Watch client class?

--- a/app/tests/test_process_requests.py
+++ b/app/tests/test_process_requests.py
@@ -2,6 +2,8 @@ import pytest
 import respx
 import httpx
 from fastapi.testclient import TestClient
+
+from app.core import settings
 from app.core.errors import TooManyRequests
 from app.main import app
 
@@ -42,7 +44,8 @@ async def test_process_cameratrap_file_successfully(
         assert route.called
         # Check that the file was retrieved and deleted from GCP
         assert mock_cloud_storage_client.download.called
-        assert mock_cloud_storage_client.delete.called
+        if settings.DELETE_FILES_AFTER_DELIVERY:
+            assert mock_cloud_storage_client.delete.called
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What does this PR do?
- Add a setting to enable/disable the file deletion after they are dispatched to WPS Watch, so we can disable it if there is a retention policy in the bucket.

### Relevant link(s)
[GUNDI-2855](https://allenai.atlassian.net/browse/GUNDI-2855)

[GUNDI-2855]: https://allenai.atlassian.net/browse/GUNDI-2855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ