### PR TITLE
GUNDI-3144: Update gundi-client to fix issue with expired tokens

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -85,7 +85,7 @@ grpcio==1.60.0
     #   grpcio-status
 grpcio-status==1.60.0
     # via google-api-core
-gundi-client==1.0.1
+gundi-client==1.0.2
     # via -r requirements.in
 gundi-core==1.3.0
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ walrus==0.9.2
 aioredis==2.0.1
 hiredis==2.3.2
 gundi-core==1.3.0
-gundi-client==1.0.1
+gundi-client==1.0.2
 httpx==0.24.1
 gcloud-aio-pubsub==6.0.0
 gcloud-aio-storage==9.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,7 +83,7 @@ grpcio==1.60.0
     #   grpcio-status
 grpcio-status==1.60.0
     # via google-api-core
-gundi-client==1.0.1
+gundi-client==1.0.2
     # via -r requirements.in
 gundi-core==1.3.0
     # via


### PR DESCRIPTION
This PR updates the gundi-client version to [v1.0.2](https://github.com/PADAS/gundi-client/releases/tag/v1.0.2) to get a fix for expired tokens.