### PR TITLE
GUNDI-3249: Add tracing on success or error

### DIFF
--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -121,14 +121,15 @@ async def dispatch_image(
     data_provider_id = attributes.get("data_provider_id")
     destination_id = attributes.get("destination_id")
     with tracing.tracer.start_as_current_span(
-        "wpswatch_dispatcher.dispatch_image", kind=SpanKind.CONSUMER
+        "wpswatch_dispatcher.dispatch_image", kind=SpanKind.CLIENT
     ) as current_span:
         try:
             dispatcher = WPSWatchImageDispatcher(integration=integration)
             result = await dispatcher.send(image=image, related_event=related_event)
         except Exception as e:
             with tracing.tracer.start_as_current_span(
-                "er_dispatcher.error_dispatching_observation", kind=SpanKind.CLIENT
+                "wpswatch_dispatcher.error_dispatching_observation",
+                kind=SpanKind.CLIENT,
             ) as error_span:
                 error_msg = f"Error dispatching observation {gundi_id} to destination {destination_id}: {type(e)}: {e}"
                 logger.exception(error_msg)


### PR DESCRIPTION
### What does this PR do?
- Adds the usual success/error indicators in traces such as `is_dispatched_successfully` and `error` which I forgot to add during the implementation. 

### Relevant link(s)
[GUNDI-3249](https://allenai.atlassian.net/browse/GUNDI-3249)

[GUNDI-3249]: https://allenai.atlassian.net/browse/GUNDI-3249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ